### PR TITLE
Only update new files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ do
   EXCLUDE="$EXCLUDE --exclude $excludedPath"
 done
 
-lftp $INPUT_FTP_HOST -u $INPUT_FTP_USERNAME,$INPUT_FTP_PASSWORD -e "$([ "$INPUT_DISABLE_SSL_CERTIFICATE_VERIFICATION" == true ] && echo "set ssl:verify-certificate false;") mirror --verbose --reverse $([ "$INPUT_DELETE" == true ] && echo "--delete") $EXCLUDE $INPUT_LOCAL_SOURCE_DIR $INPUT_DIST_TARGET_DIR; exit"
+lftp $INPUT_FTP_HOST -u $INPUT_FTP_USERNAME,$INPUT_FTP_PASSWORD -e "$([ "$INPUT_DISABLE_SSL_CERTIFICATE_VERIFICATION" == true ] && echo "set ssl:verify-certificate false;") mirror --only-newer --verbose --reverse $([ "$INPUT_DELETE" == true ] && echo "--delete") $EXCLUDE $INPUT_LOCAL_SOURCE_DIR $INPUT_DIST_TARGET_DIR; exit"


### PR DESCRIPTION
Added option to only update new/changed files. This does not work on every server you may add `--ignore-time`, then it will only look if the file size is different. This could make troubles but should be fine most of the time.