### PR TITLE
[Discussion] simple option for "other lftp flags"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ Fill an array of regex. E.g. `"'^logs/' '^README.md'"`
 
 Disable SSL certificate verification. Default `"true"`.
 
+### `other_flags`
+
+Optional, can be used to set raw string of flag(s) or option(s) for lftp eg. `"--no-empty-dirs --ascii"`, you can refer to the official docs for the full list of available flags and options. <https://lftp.yar.ru/lftp-man.html>
+
 ## Example usage
 
-```
+```bash
 uses: kevinpainchaud/simple-ftp-deploy-action@v1.1.0
 with:
   ftp_host: ${{ secrets.FTP_HOST }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Disable SSL certificate verification"
     required: false
     default: "true"
+  other_flags:
+    description: "Optional raw string of flags for lftp eg. --no-empty-dirs"
+    required: false
+    default: ""
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ do
   EXCLUDE="$EXCLUDE --exclude $excludedPath"
 done
 
-lftp $INPUT_FTP_HOST -u $INPUT_FTP_USERNAME,$INPUT_FTP_PASSWORD -e "$([ "$INPUT_DISABLE_SSL_CERTIFICATE_VERIFICATION" == true ] && echo "set ssl:verify-certificate false;") mirror --verbose --reverse $([ "$INPUT_DELETE" == true ] && echo "--delete") $([ "$INPUT_ONLY_NEWER" == true ] && echo "--only-newer") $([ "$INPUT_IGNORE_TIME" == true ] && echo "--ignore-time") $EXCLUDE $INPUT_LOCAL_SOURCE_DIR $INPUT_DIST_TARGET_DIR; exit"
+lftp $INPUT_FTP_HOST -u $INPUT_FTP_USERNAME,$INPUT_FTP_PASSWORD -e "$([ "$INPUT_DISABLE_SSL_CERTIFICATE_VERIFICATION" == true ] && echo "set ssl:verify-certificate false;") mirror --verbose --reverse $([ "$INPUT_DELETE" == true ] && echo "--delete") $([ "$INPUT_ONLY_NEWER" == true ] && echo "--only-newer") $([ "$INPUT_IGNORE_TIME" == true ] && echo "--ignore-time") $OTHER_FLAGS $EXCLUDE $INPUT_LOCAL_SOURCE_DIR $INPUT_DIST_TARGET_DIR; exit"


### PR DESCRIPTION
I could see that in future more and more people want to use different flags. Maybe it is a good idea to simple make an option where you can insert a raw string of flags for lftp. Then you don't need to implement each option.

See my pull request as an example for a possible implementation of this proposed feature.

Cheers
Hannes